### PR TITLE
Allow refresh_tokens and try to Transform Requests

### DIFF
--- a/model.coffee
+++ b/model.coffee
@@ -48,7 +48,7 @@ debug = undefined
 		if debug is true
 			console.log '[OAuth2Server]', 'in grantTypeAllowed (clientId:', clientId, ', grantType:', grantType + ')'
 
-		return callback(false, grantType in ['authorization_code'])
+		return callback(false, grantType in ['authorization_code', 'refresh_token'])
 
 
 	saveAccessToken: Meteor.bindEnvironment (token, clientId, expires, user, callback) ->

--- a/oauth.coffee
+++ b/oauth.coffee
@@ -45,15 +45,17 @@ class OAuth2Server
 				console.log '[OAuth2Server]', req.method, req.url
 			next()
 
-		fixZapierNotUsingFormUrlencodedType = (req, res, next) ->
-			if not req.is('application/x-www-form-urlencoded') and req.method is 'POST' and req.get('user-agent') is 'Zapier'
+		# Transforms requests which are POST and aren't "x-www-form-urlencoded" content type
+		# and they pass the required information as query strings
+		transformRequestsNotUsingFormUrlencodedType = (req, res, next) ->
+			if not req.is('application/x-www-form-urlencoded') and req.method is 'POST'
 				if self.config.debug is true
-					console.log '[OAuth2Server]', 'Transforming a request for Zapier. To form-urlencoded and query to body.'
+					console.log '[OAuth2Server]', 'Transforming a request to form-urlencoded with the query going to the body.'
 				req.headers['content-type'] = 'application/x-www-form-urlencoded'
 				req.body = req.query
 			next()
 
-		@app.all '/oauth/token', debugMiddleware, fixZapierNotUsingFormUrlencodedType, @oauth.grant()
+		@app.all '/oauth/token', debugMiddleware, transformRequestsNotUsingFormUrlencodedType, @oauth.grant()
 
 		@app.get '/oauth/authorize', debugMiddleware, Meteor.bindEnvironment (req, res, next) ->
 			client = self.model.Clients.findOne({ active: true, clientId: req.query.client_id })

--- a/oauth.coffee
+++ b/oauth.coffee
@@ -52,7 +52,7 @@ class OAuth2Server
 				if self.config.debug is true
 					console.log '[OAuth2Server]', 'Transforming a request to form-urlencoded with the query going to the body.'
 				req.headers['content-type'] = 'application/x-www-form-urlencoded'
-				req.body = req.query
+				req.body = Object.assign {}, req.body, req.query
 			next()
 
 		@app.all '/oauth/token', debugMiddleware, transformRequestsNotUsingFormUrlencodedType, @oauth.grant()


### PR DESCRIPTION
This allows `refresh_tokens` to be used as a grant type, which allows for applications to successfully refresh their access tokens. Also, I added a method which will try to transform requests which aren't the expected type. Which ends up being if the request's `content-type` is not `application/x-www-form-urlencoded` and it is `POST`ing, then we will copy the query strings into the request's body. This is needed for Zapier, but I have made it generic per suggetion of Gabriel. _Note:_ The request `application/x-www-form-urlencoded` is required is due to the nodejs module we're using.